### PR TITLE
Fix map open target

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "items": [
     {
-      "page": "plow_status_addin",
+      "page": "plow_status_addin.html",
       "title": "Plow Status",
       "svgIcon": "https://shankargeotab.github.io/mygeotab-newaddin/icon.svg",
       "noView": false

--- a/plowStatusMap.js
+++ b/plowStatusMap.js
@@ -16,7 +16,7 @@ window.geotab.addin.plow_status_addin_map = function(api, state) {
       btn.id        = "plowStatusButton";
       btn.innerText = "Show Plow Status";
       btn.style.padding = "5px";
-      btn.onclick = () => state.open("plow_status_addin");
+      btn.onclick = () => state.open("plow_status_addin.html");
       toolbar.appendChild(btn);
       console.log("✅ Plow Status button added");
     },


### PR DESCRIPTION
## Summary
- update addin entry page reference in manifest
- ensure the map button opens the addin HTML page

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68431181e9e8832cb43b6bd83221d19a