### PR TITLE
Fix README canonical page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ This Add-in displays the Plow status using **Aux 6** in MyGeotab.
 
 ## Installation:
 1. Add this URL to **MyGeotab > Administration > System Settings > Add-ins**:
+   https://shankargeotab.github.io/mygeotab-newaddin/plow_status_addin.html


### PR DESCRIPTION
## Summary
- clarify canonical HTML page by linking `plow_status_addin.html` directly in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843119556a0832c8532d263ad028e76