### PR TITLE
Limit plow status query to recent window

### DIFF
--- a/plowStatusAddIn.js
+++ b/plowStatusAddIn.js
@@ -20,9 +20,14 @@ window.geotab.addin.plow_status_addin = {
 
     const updatePlowStatus = async () => {
       try {
+        const toDate = new Date();
+        const fromDate = new Date(toDate.getTime() - 5 * 60 * 1000);
+
         const data = await api.call("Get", {
           typeName: "StatusData",
           search: {
+            fromDate,
+            toDate,
             diagnosticSearch: {
               id: [
                 "DiagnosticAux6Id",


### PR DESCRIPTION
## Summary
- restrict `StatusData` calls to the last five minutes

## Testing
- `node -c plowStatusAddIn.js`

------
https://chatgpt.com/codex/tasks/task_e_684314498450832cb734326cbba1eb45